### PR TITLE
More flexible configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM jonasbn/ebirah:0.6.0
 
+WORKDIR /opt
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 


### PR DESCRIPTION
- Allows repositories that doesn't have a cpanfile to have their dependencies installed.
- Replaced dash with Bash, since it's already available in the image and has more features.
- Allow the optional configuration of the CPAN client, since it might be required by some distributions.
- Small improvements regarding DRY.
